### PR TITLE
Set week to start on Sunday

### DIFF
--- a/cron/jquery-cron.js
+++ b/cron/jquery-cron.js
@@ -132,8 +132,8 @@
     
     // options for day of week
     var str_opt_dow = "";
-    var days = ["Monday", "Tuesday", "Wednesday", "Thursday",
-                "Friday", "Saturday", "Sunday"];
+    var days = ["Sunday", "Monday", "Tuesday", "Wednesday", "Thursday",
+                "Friday", "Saturday"];
     for (var i = 0; i < days.length; i++) {
         str_opt_dow += "<option value='"+i+"'>" + days[i] + "</option>\n"; 
     }


### PR DESCRIPTION
Cron weeks start on a Sunday. Thus Sunday should be 0 (see http://en.wikipedia.org/wiki/Cron#Predefined_scheduling_definitions ).
FWIW this tallies with JavaScript's `.getDay()` function.
