### PR TITLE
Loading jQuery through HTTPS

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
     <title>jquery-cron : a jQuery plugin</title>
     <link type="text/css" href="gentleSelect/jquery-gentleSelect.css" rel="stylesheet" />
     <link type="text/css" href="cron/jquery-cron.css" rel="stylesheet" />
-    <script type="text/javascript" src="http://ajax.googleapis.com/ajax/libs/jquery/1.4/jquery.min.js"></script>
+    <script type="text/javascript" src="https://ajax.googleapis.com/ajax/libs/jquery/1.4/jquery.min.js"></script>
     <script type="text/javascript" src="gentleSelect/jquery-gentleSelect-min.js"></script>
     <script type="text/javascript" src="cron/jquery-cron.js"></script>
 


### PR DESCRIPTION
Loading jQuery through HTTP instead of HTTPS an issue as content on GitHub Pages is served through HTTPS. jQuery is not loaded because of Mixed content error.
