### PR TITLE
fix for user selecting weekly

### DIFF
--- a/cron/jquery-cron.js
+++ b/cron/jquery-cron.js
@@ -136,7 +136,7 @@
     var days = ["Sunday", "Monday", "Tuesday", "Wednesday", "Thursday",
                 "Friday", "Saturday"];
     for (var i = 0; i < days.length; i++) {
-        str_opt_dow += "<option value='"+i+"'>" + days[i] + "</option>\n";
+        str_opt_dow += "<option value='"+(i+1)+"'>" + days[i] + "</option>\n";
     }
 
     // options for period


### PR DESCRIPTION
fix bug when user selects weekly on Sunday (which would have the value of i (which was 0) and threw an error stating the value for days must be between 1-7)